### PR TITLE
会員側テーブルの調整、他

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -47,3 +47,7 @@ header, nav, body, h2, footer {
   transform: translate(-50%,-50%);
   filter: drop-shadow(5px 5px 3px rgba(20,20,20,0.6));
 }
+
+.table-hover tbody tr:hover{
+  background-color: #B0E0E6;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -48,6 +48,14 @@ header, nav, body, h2, footer {
   filter: drop-shadow(5px 5px 3px rgba(20,20,20,0.6));
 }
 
+.table-hover tbody tr{
+  background-color: #FFFFFF;
+  -webkit-transition: all 0.3s ease;
+  -moz-transition: all 0.3s ease;
+  -o-transition: all 0.3s ease;
+  transition: all  0.3s ease;
+}
+
 .table-hover tbody tr:hover{
   background-color: #B0E0E6;
 }

--- a/app/controllers/admin/boards_controller.rb
+++ b/app/controllers/admin/boards_controller.rb
@@ -5,12 +5,14 @@ class Admin::BoardsController < ApplicationController
     @residences = current_admin.residences
     @residence_id_array = @residences.pluck(:id)
     @boards = Board.where(residence_id: @residence_id_array)
+    @reads = Read.all
   end
 
   def residence_search
     @residences = current_admin.residences
     @residence = Residence.find(params[:id])
     @boards = @residence.boards
+    @reads = Read.all
   end
 
   def show

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -21,6 +21,7 @@ class Admin::CommunitiesController < ApplicationController
 
   def edit
     @community = Community.find(params[:id])
+    @residence = @community.residence
   end
 
   def update

--- a/app/controllers/admin/event_members_controller.rb
+++ b/app/controllers/admin/event_members_controller.rb
@@ -24,10 +24,12 @@ class Admin::EventMembersController < ApplicationController
     @event = Event.find(params[:event_id])
     @residence_members = @event.residence.members
     @residence_members.each do |member|
-      unless EventMember.find_or_create_by(event_id: @event.id, member_id: member.id, is_approved: false)
-        flash.now[:notice] =　"#{member}の招待に失敗しました。"
-        render "index"
-        return
+      if not EventMember.find_by(event_id: @event.id, member_id: member.id, is_approved: true).present?
+        unless EventMember.find_or_create_by(event_id: @event.id, member_id: member.id, is_approved: false)
+          flash.now[:notice] =　"#{member}の招待に失敗しました。"
+          render "index"
+          return
+        end
       end
     end
     redirect_to admin_event_event_members_path(@event)

--- a/app/controllers/admin/exchanges_controller.rb
+++ b/app/controllers/admin/exchanges_controller.rb
@@ -20,6 +20,7 @@ class Admin::ExchangesController < ApplicationController
 
   def edit
     @exchange = Exchange.find(params[:id])
+    @residence = @exchange.residence
   end
 
   def update

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -6,6 +6,7 @@ class Admin::SearchesController < ApplicationController
 
   def search_result
     @category = params[:category]
+    @reads = Read.all
 
     if @category == "all"
       @boards = Board.looks(params[:word], params[:residence_id])

--- a/app/controllers/public/community_members_controller.rb
+++ b/app/controllers/public/community_members_controller.rb
@@ -24,7 +24,7 @@ class Public::CommunityMembersController < ApplicationController
     @community = Community.find(params[:community_id])
     community_member = CommunityMember.find(params[:id])
     if community_member.update(community_member_params)
-      redirect_to public_community_path(@community)
+      redirect_to public_community_community_members_path(@community)
     else
       flash.now[:notice] = "コミュニティメンバーの更新に失敗しました。"
       @community_members = @community.community_members

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,3 +16,9 @@ import "../stylesheets/application";
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
+
+jQuery(document).on("turbolinks:load", function() {
+  $(".index_tr").on('click', function() {
+      window.location = $(this).data("href");
+  });
+});

--- a/app/models/residence.rb
+++ b/app/models/residence.rb
@@ -14,4 +14,7 @@ class Residence < ApplicationRecord
 
   enum housing_type: { apartment: 0, house: 1 }
 
+  validates :name, presence: true
+  validates :address, presence: true
+
 end

--- a/app/views/admin/boards/_index.html.erb
+++ b/app/views/admin/boards/_index.html.erb
@@ -1,17 +1,22 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>作成者</th>
       <th>名称</th>
       <th>本文</th>
       <th>回覧</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
     <% boards.each do |board| %>
       <tr>
-        <td><%= board.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= board.residence.name %></td>
+        <% end %>
         <% if board.member_id == 0 %>
           <td>管理人</td>
         <% else %>
@@ -19,7 +24,19 @@
         <% end %>
         <td><%= link_to board.name, admin_board_path(board) %></td>
         <td><%= board.body.truncate(40) %></td>
-        <td><%= board.is_circular %></td>
+        <% if board.is_circular == true %>
+          <td class="text-center text-weight-bold text-success"><i class="fa-solid fa-check"></i></td>
+          <% if board.circular_members.count == 0 %>
+            <td>回覧メンバー未設定</td>
+          <% elsif reads.where(board_id: board.id, member_id: board.circular_members.pluck(:member_id)).count == board.circular_members.count && board.circular_members.exists? %>
+            <td class="text-success">全員確認済み</td>
+          <% else %>
+            <td>確認済み<%= Read.where(board_id: board.id, member_id: board.circular_members.pluck(:member_id)).count %>/<%= board.circular_members.count %></td>
+          <% end %>
+        <% else %>
+          <td class="text-center">-</td>
+          <td></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/boards/index.html.erb
+++ b/app/views/admin/boards/index.html.erb
@@ -7,24 +7,30 @@
       <div class="row mr-3 mb-3">
         <h2>掲示板一覧</h2>
         <div class="ml-auto">
-          <table><tr>
-            <%= form_with model: Board, url: new_admin_board_path, method: :get, local: true do |f| %>
-              <td><%=
-                f.select :residence_id,
-                options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-                required: true,
-                class: 'form-control'
-              %></td>
-              <td><%= f.submit "選択した居住地に掲示板を登録", class: 'btn btn-sm btn-success' %></td>
-            <% end %>
-          </tr></table>
+          <%= form_with model: Board, url: new_admin_board_path, method: :get, local: true do |f| %>
+            <table class="table table-borderless table-sm">
+              <tr>
+                <td class="align-middle">
+                  <%=
+                    f.select :residence_id,
+                    options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
+                    required: true,
+                    class: 'form-control'
+                  %>
+                </td>
+                <td class="align-middle">
+                  <%= f.submit "選択した居住地に掲示板を登録", class: 'btn btn-sm btn-success' %>
+                </td>
+              </tr>
+            </table>
+          <% end %>
         </div>
       </div>
       <div class="container">
         <div class="ml-3">
-            <%= render 'admin/boards/index', boards: @boards %>
+          <%= render 'admin/boards/index', boards: @boards, reads: @reads %>
         </div>
       </div>
-     </div>
+    </div>
   </div>
 </div>

--- a/app/views/admin/boards/residence_search.html.erb
+++ b/app/views/admin/boards/residence_search.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="container">
         <div class="ml-3">
-          <%= render 'admin/boards/index', boards: @boards %>
+          <%= render 'admin/boards/index', boards: @boards, reads: @reads %>
         </div>
       </div>
      </div>

--- a/app/views/admin/circular_members/index.html.erb
+++ b/app/views/admin/circular_members/index.html.erb
@@ -13,13 +13,13 @@
                 <% if @board.circular_members.exists?(member_id: member.id) %>
                   <td><%= link_to "削除", admin_board_circular_member_path(@board.id, member.id), method: :delete, class: 'btn btn-sm btn-danger' %></td>
                 <% else %>
-                  <%= form_with model:@circular_member, url: admin_board_circular_members_path(@board), local: true do |f| %>
-                    <td>
+                  <td>
+                    <%= form_with model:@circular_member, url: admin_board_circular_members_path(@board), local: true do |f| %>
                       <%= f.hidden_field :board_id, :value => params[:board_id] %>
                       <%= f.hidden_field :member_id, :value => member.id %>
                       <%= f.submit "追加", class: 'btn btn-sm btn-success' %>
-                    </td>
-                  <% end %>
+                    <% end %>
+                  </td>
                 <% end %>
               <% end %>
             </tr>

--- a/app/views/admin/communities/_form.html.erb
+++ b/app/views/admin/communities/_form.html.erb
@@ -5,12 +5,9 @@
       <tbody>
         <div class="form-group">
           <tr>
-            <td><%= f.label :居住地 %></td>
-            <td>
-              <%= f.select :residence_id,
-              options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-              class: 'form-control' %>
-            </td>
+            <td>居住地</td>
+            <td><%= residence.name %></td>
+            <%= f.hidden_field :residence_id, :value => residence.id %>
           </tr>
         </div>
         <div class="form-group">

--- a/app/views/admin/communities/_index.html.erb
+++ b/app/views/admin/communities/_index.html.erb
@@ -1,7 +1,9 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>作成者</th>
       <th>コミュニティ名</th>
       <th>説明</th>
@@ -11,7 +13,9 @@
   <tbody>
     <% communities.each do |community| %>
       <tr>
-        <td><%= community.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= community.residence.name %></td>
+        <% end %>
         <td><%= community.member.name %></td>
         <td><%= link_to community.name, admin_community_path(community) %></td>
         <td><%= community.description %></td>

--- a/app/views/admin/communities/edit.html.erb
+++ b/app/views/admin/communities/edit.html.erb
@@ -4,7 +4,7 @@
       <div class="ml-5 mb-3">
         <h2>コミュニティ投稿編集</h2>
       </div>
-      <%= render 'admin/communities/form', community: @community, path: admin_community_path %>
+      <%= render 'admin/communities/form', community: @community, path: admin_community_path, residence: @residence %>
     </div>
   </div>
 </div>

--- a/app/views/admin/communities/show.html.erb
+++ b/app/views/admin/communities/show.html.erb
@@ -5,93 +5,113 @@
         <h2>コミュニティ詳細</h2>
       </div>
       <div class="container">
-        <div class="offset-1">
-          <table class='table table-borderless'>
-            <tr><th style="width: 20%">作成者名</th><td><%= @community.member.name %></td></tr>
-            <tr><th>居住地</th><td><%= @community.residence.name %></td></tr>
-            <tr><th>コミュニティ名</th><td><%= image_tag @community.get_community_image, width: '50px' %><%= @community.name %></td></tr>
-            <tr><th>説明</th><td><%= @community.description %></td></tr>
-          </table>
-          <div class="row">
-            <div class="mx-auto">
-              <%= link_to "編集する", edit_admin_community_path, class: "btn btn-success" %>&emsp;&emsp;
-              <%= link_to "削除する", admin_community_path, method: :delete,
-                data: {confirm:'本当に削除してよろしいですか？'}, class: "btn btn-danger" %>
+        <div class="col-md-10 offset-1">
+          <div class="mb-3">
+            <table class='table table-borderless'>
+              <tr><th style="width: 20%">作成者名</th><td><%= @community.member.name %></td></tr>
+              <tr><th>居住地</th><td><%= @community.residence.name %></td></tr>
+              <tr><th>コミュニティ名</th><td><%= image_tag @community.get_community_image, width: '50px' %><%= @community.name %></td></tr>
+              <tr><th>説明</th><td><%= @community.description %></td></tr>
+            </table>
+            <div class="row">
+              <div class="mx-auto">
+                <%= link_to "編集する", edit_admin_community_path, class: "btn btn-success" %>&emsp;&emsp;
+                <%= link_to "削除する", admin_community_path, method: :delete,
+                  data: {confirm:'本当に削除してよろしいですか？'}, class: "btn btn-danger" %>
+              </div>
             </div>
           </div>
-          <div class="row">
-            <!--参加メンバー表示用の記述-->
-            <div class="col-6 mt-5">
-              <div class="row mb-3 d-flex align-items-center">
-                <h4>参加メンバー</h4>&emsp;
-                <span class="text-primary font-weight-bold"><%= @community_members.count %>人</span>
-              </div>
-              <table class='table table-borderless'>
-                <tbody>
-                  <% @community_members.each do |community_member| %>
-                    <tr>
-                      <td style="width: 35%"><%= community_member.member.name %></td>
-                      <!--管理者かどうかの確認と切り替え処理-->
-                      <% if community_member.is_admin == true %>
-                        <td class="text-danger">管理者</td>
-                        <%= form_with model: CommunityMember.new, url: admin_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+          <!--タブ切り替え-->
+          <div class="tabs">
+            <ul class="nav nav-tabs">
+              <li class="nav-item">
+                <a class="nav-link active" data-toggle="tab" href="#section1">参加メンバー</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" data-toggle="tab" href="#section2">コメント</a>
+              </li>
+            </ul>
+
+            <div class="tab-content">
+              <div id="section1" class="tab-pane fade show active">
+                <!--参加メンバー表示用の記述-->
+                <div class="col-md-8 mt-5">
+                  <div class="row mb-3 d-flex align-items-center">
+                    <h4>参加メンバー</h4>&emsp;
+                    <span class="text-primary font-weight-bold"><%= @community_members.count %>人</span>
+                  </div>
+                  <table class='table table-borderless'>
+                    <tbody>
+                      <% @community_members.each do |community_member| %>
+                        <tr>
+                          <td style="width: 35%"><%= community_member.member.name %></td>
+                          <!--管理者かどうかの確認と切り替え処理-->
+                          <% if community_member.is_admin == true %>
+                            <td class="text-danger">管理者</td>
+                            <td>
+                              <%= form_with model: CommunityMember.new, url: admin_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+                                <%= f.hidden_field :is_admin, :value => false %>
+                                <%= f.submit "メンバーに変更", class: 'btn btn-sm btn-success' %>
+                              <% end %>
+                            </td>
+                          <% else %>
+                            <td class="text-success">メンバー</td>
+                            <td>
+                              <%= form_with model: CommunityMember.new, url: admin_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+                                <%= f.hidden_field :is_admin, :value => true %>
+                                <%= f.submit "管理者に変更", class: 'btn btn-sm btn-danger' %>
+                              <% end %>
+                            </td>
+                          <% end %>
+                          <!--管理者かどうかの確認と切り替え処理ここまで-->
                           <td>
-                            <%= f.hidden_field :is_admin, :value => false %>
-                            <%= f.submit "メンバーに変更", class: 'btn btn-sm btn-success' %>
+                            <%= link_to admin_community_community_member_path(@community, community_member), method: :delete, class: 'btn btn-sm btn-secondary' do %>
+                              <i class="fa-solid fa-trash-can fa-2xs"></i>
+                            <% end %>
                           </td>
-                        <% end %>
-                      <% else %>
-                        <td class="text-success">メンバー</td>
-                        <%= form_with model: CommunityMember.new, url: admin_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
-                          <td>
-                            <%= f.hidden_field :is_admin, :value => true %>
-                            <%= f.submit "管理者に変更", class: 'btn btn-sm btn-danger' %>
-                          </td>
-                        <% end %>
+                        </tr>
                       <% end %>
-                      <!--管理者かどうかの確認と切り替え処理ここまで-->
-                      <td>
-                        <%= link_to admin_community_community_member_path(@community, community_member), method: :delete, class: 'btn btn-sm btn-secondary' do %>
-                          <i class="fa-solid fa-trash-can fa-2xs"></i>
-                        <% end %>
-                      </td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-            <!--参加メンバー表示用の記述ここまで-->
-            <!--コメント表示用の記述-->
-            <div class="col-6 mt-5">
-              <div class="row mb-3 d-flex align-items-center">
-                <h4>コメント</h4>&emsp;
-                <span class="text-primary font-weight-bold"><%= @community_comments.count %>件</span>
+                    </tbody>
+                  </table>
+                </div>
+                <!--参加メンバー表示用の記述ここまで-->
               </div>
-              <table class='table table-borderless'>
-                <tbody>
-                  <% @community_comments.each do |community_comment| %>
-                    <tr>
-                      <td style="width: 35%"><%= community_comment.member.name %></td>
-                      <td><%= community_comment.comment %></td>
-                      <!--コメントを論理削除するための処理-->
-                      <% if community_comment.is_deleted == true %>
-                        <td class="text-danger">削除済み</td>
-                      <% else %>
-                        <%= form_with model: CommunityComment.new, url: admin_community_community_comment_path(@community, community_comment), method: :patch, local: true do |f| %>
-                          <td>
-                            <%= f.hidden_field :is_deleted, :value => true %>
-                            <%= f.submit "コメントを削除する", class: 'btn btn-sm btn-danger' %>
-                          </td>
-                        <% end %>
+
+              <div id="section2" class="tab-pane fade">
+                <!--コメント表示用の記述-->
+                <div class="col-md-10 mt-5">
+                  <div class="row mb-3 d-flex align-items-center">
+                    <h4>コメント</h4>&emsp;
+                    <span class="text-primary font-weight-bold"><%= @community_comments.count %>件</span>
+                  </div>
+                  <table class='table table-borderless'>
+                    <tbody>
+                      <% @community_comments.each do |community_comment| %>
+                        <tr>
+                          <td style="width: 35%"><%= community_comment.member.name %></td>
+                          <td><%= community_comment.comment %></td>
+                          <!--コメントを論理削除するための処理-->
+                          <% if community_comment.is_deleted == true %>
+                            <td class="text-danger">削除済み</td>
+                          <% else %>
+                            <td>
+                              <%= form_with model: CommunityComment.new, url: admin_community_community_comment_path(@community, community_comment), method: :patch, local: true do |f| %>
+                                <%= f.hidden_field :is_deleted, :value => true %>
+                                <%= f.submit "コメントを削除する", class: 'btn btn-sm btn-danger' %>
+                              <% end %>
+                            </td>
+                          <% end %>
+                          <!--コメントを論理削除するための処理ここまで-->
+                        </tr>
                       <% end %>
-                      <!--コメントを論理削除するための処理ここまで-->
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
+                    </tbody>
+                  </table>
+                </div>
+                <!--コメント表示用の記述ここまで-->
+              </div>
             </div>
-            <!--コメント表示用の記述ここまで-->
           </div>
+          <!--タブ切り替えここまで-->
         </div>
       </div>
     </div>

--- a/app/views/admin/equipments/_index.html.erb
+++ b/app/views/admin/equipments/_index.html.erb
@@ -1,32 +1,28 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>名称</th>
-      <th>説明</th>
       <th>ジャンル</th>
       <th>在庫</th>
-      <th>保管場所</th>
-      <th>返却場所</th>
-      <th>メモ</th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% equipments.each do |equipment| %>
       <tr>
-        <td><%= equipment.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= equipment.residence.name %></td>
+        <% end %>
         <td><%= link_to equipment.name, admin_equipment_path(equipment) %></td>
-        <td><%= equipment.description %></td>
         <% if equipment.genre_id == 0 %>
           <td>(未設定)</td>
         <% else %>
           <td><%= equipment.genre.name %></td>
         <% end %>
         <td><%= equipment.stock %>個</td>
-        <td><%= equipment.storage_location %></td>
-        <td><%= equipment.return_location %></td>
-        <td><%= equipment.note %></td>
         <td>
           <%= form_with model: Reservation, url: new_admin_reservation_path, method: :get, local: true do |f| %>
             <%= f.hidden_field :equipment_id, :value => equipment.id %>

--- a/app/views/admin/equipments/index.html.erb
+++ b/app/views/admin/equipments/index.html.erb
@@ -7,17 +7,23 @@
       <div class="row mr-3 mb-3">
         <h2>備品一覧</h2>
         <div class="ml-auto">
-          <table><tr>
           <%= form_with model: Equipment, url: new_admin_equipment_path, method: :get, local: true do |f| %>
-            <td><%=
-              f.select :residence_id,
-              options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-              required: true,
-              class: 'form-control'
-            %></td>
-            <td><%= f.submit "選択した居住地に備品を登録", class: 'btn btn-sm btn-success' %></td>
+            <table class="table table-borderless table-sm">
+              <tr>
+                <td class="align-middle">
+                  <%=
+                    f.select :residence_id,
+                    options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
+                    required: true,
+                    class: 'form-control'
+                  %>
+                </td>
+                <td class="align-middle">
+                  <%= f.submit "選択した居住地に備品を登録", class: 'btn btn-sm btn-success' %>
+                </td>
+              </tr>
+            </table>
           <% end %>
-          </tr></table>
         </div>
       </div>
       <div class="container">

--- a/app/views/admin/event_members/index.html.erb
+++ b/app/views/admin/event_members/index.html.erb
@@ -33,8 +33,10 @@
             <tr>
               <% if @event.event_members.where(member_id: member.id).present? %>
                 <% if @event.event_members.find_by(member_id: member.id).is_approved == false %>
-                  <td style="width:30%"><%= member.name %></td>
-                  <td class="text-success">招待中</td>
+                  <td style="width:30%">
+                    <%= member.name %>
+                    <span class="text-success">招待中</span>
+                  </td>
                   <% if @event.member == current_member %>
                     <td><%= link_to "招待を取り消す", admin_event_event_member_quit_invite_path(@event.id, @event.event_members.find_by(member_id: member.id)), method: :delete, class: "btn btn-secondary" %></td>
                   <% else %>
@@ -43,7 +45,6 @@
                 <% end %>
               <% else %>
                 <td style="width:30%"><%= member.name %></td>
-                <td></td>
                 <% if @event.member == current_member %>
                   <td>
                     <%= form_with model:EventMember.new, url: admin_event_event_members_path(@event), local: true do |f| %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -31,7 +31,7 @@
         <div class="form-group">
           <tr>
             <td><%= f.label :終了日時 %></td>
-            <td><%= f.datetime_select :finished_at, min: Date.today, class: 'form-control' %></td>
+            <td><%= f.datetime_field :finished_at, min: Date.today, class: 'form-control' %></td>
           </tr>
         </div>
         <div class="form-group">

--- a/app/views/admin/events/_index.html.erb
+++ b/app/views/admin/events/_index.html.erb
@@ -1,10 +1,11 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>作成者</th>
       <th>イベント名</th>
-      <th>説明</th>
       <th>開催期間</th>
       <th>開催場所</th>
     </tr>
@@ -12,14 +13,15 @@
   <tbody>
     <% events.each do |event| %>
       <tr>
-        <td><%= event.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= event.residence.name %></td>
+        <% end %>
         <% if event.member_id == 0 %>
           <td>管理人</td>
         <% else %>
           <td><%= event.member.name %></td>
         <% end %>
         <td><%= link_to event.name, admin_event_path(event) %></td>
-        <td><%= event.description %></td>
         <td><%= l event.started_at %> ~ <%= l event.finished_at %></td>
         <td><%= event.venue %></td>
       </tr>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -7,17 +7,23 @@
       <div class="row mr-3 mb-3">
         <h2>イベント一覧</h2>
         <div class="ml-auto">
-          <table><tr>
-            <%= form_with model: Event, url: new_admin_event_path, method: :get, local: true do |f| %>
-              <td><%=
-                f.select :residence_id,
-                options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-                required: true,
-                class: 'form-control'
-              %></td>
-              <td><%= f.submit "選択した居住地にイベントを登録", class: 'btn btn-sm btn-success' %></td>
-            <% end %>
-          </tr></table>
+          <%= form_with model: Event, url: new_admin_event_path, method: :get, local: true do |f| %>
+            <table class="table table-borderless table-sm">
+              <tr>
+                <td class="align-middle">
+                  <%=
+                    f.select :residence_id,
+                    options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
+                    required: true,
+                    class: 'form-control'
+                  %>
+                </td>
+                <td class="align-middle">
+                  <%= f.submit "選択した居住地にイベントを登録", class: 'btn btn-sm btn-success' %></td>
+                </td>
+              </tr>
+            </table>
+          <% end %>
         </div>
       </div>
       <div class="container">

--- a/app/views/admin/exchanges/_form.html.erb
+++ b/app/views/admin/exchanges/_form.html.erb
@@ -4,6 +4,13 @@
     <table class="table table-borderless">
       <tbody>
         <div class="form-group">
+          <tr>
+            <td>居住地</td>
+            <td><%= residence.name %></td>
+            <%= f.hidden_field :residence_id, :value => residence.id %>
+          </tr>
+        </div>
+        <div class="form-group">
           <% if @exchange.exchange_item_images.attached? %>
             <tr>
               <td><%= f.label :写真 %></td>
@@ -13,10 +20,10 @@
                   <label for="image_ids_<%= image.id %>" >
                     <%= image_tag image, width: '100px' %>
                   </label>
-                <% end %>
+                <% end %><br>
+                <span class="text-info">削除したい画像にチェックを付けてください</span>
               </td>
             </tr>
-            <span class="text-info">削除したい画像にチェックを付けてください</span>
           <% end %>
           <tr>
             <td></td>
@@ -27,16 +34,6 @@
           <tr>
             <td style="width: 20%"><%= f.label :品名 %></td>
             <td style="width: 70%"><%= f.text_field :name, placeholder: "品名", class: 'form-control' %></td>
-          </tr>
-        </div>
-        <div class="form-group">
-          <tr>
-            <td><%= f.label :居住地 %></td>
-            <td>
-              <%= f.select :residence_id,
-              options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-              class: 'form-control' %>
-            </td>
           </tr>
         </div>
         <div class="form-group">

--- a/app/views/admin/exchanges/_index.html.erb
+++ b/app/views/admin/exchanges/_index.html.erb
@@ -1,10 +1,11 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>作成者</th>
       <th>品名</th>
-      <th>説明</th>
       <th style="width:13%">費用</th>
       <th>掲載期限</th>
       <th style="width:13%">募集状況</th>
@@ -13,10 +14,11 @@
   <tbody>
     <% exchanges.each do |exchange| %>
       <tr>
-        <td><%= exchange.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= exchange.residence.name %></td>
+        <% end %>
         <td><%= exchange.member.name %></td>
         <td><%= link_to exchange.name, admin_exchange_path(exchange) %></td>
-        <td><%= exchange.description %></td>
         <% if exchange.price == 0 %>
           <td class="text-center">無償</td>
         <% else %>

--- a/app/views/admin/exchanges/edit.html.erb
+++ b/app/views/admin/exchanges/edit.html.erb
@@ -4,7 +4,7 @@
       <div class="ml-5 mb-3">
         <h2>ゆずりあい内容編集</h2>
       </div>
-      <%= render 'admin/exchanges/form', exchange: @exchange, path: admin_exchange_path %>
+      <%= render 'admin/exchanges/form', exchange: @exchange, path: admin_exchange_path, residence: @residence %>
     </div>
   </div>
 </div>

--- a/app/views/admin/exchanges/show.html.erb
+++ b/app/views/admin/exchanges/show.html.erb
@@ -7,6 +7,7 @@
       <div class="container">
         <div class="offset-1">
           <table class='table table-borderless'>
+            <tr><th>居住地</th><td><%= @exchange.residence.name %></td></tr>
             <tr>
               <th>画像</th>
               <td>
@@ -20,7 +21,6 @@
               </td>
             </tr>
             <tr><th style="width: 20%">作成者名</th><td><%= @exchange.member.name %></td></tr>
-            <tr><th>居住地</th><td><%= @exchange.residence.name %></td></tr>
             <tr><th>品名</th><td><%= @exchange.name %></td></tr>
             <tr><th>説明</th><td><%= @exchange.description %></td></tr>
             <tr>
@@ -51,7 +51,7 @@
           </div>
 
           <!--コメント表示用の記述-->
-          <div class="col-6 mt-5">
+          <div class="mt-5">
             <div class="row mb-3 d-flex align-items-center">
               <h4>コメント</h4>&emsp;
               <span class="text-primary font-weight-bold"><%= @exchange_comments.count %>件</span>
@@ -63,16 +63,18 @@
                     <td style="width: 35%"><%= exchange_comment.member.name %></td>
                     <td><%= exchange_comment.comment %></td>
                     <td>
+                      <!--コメントを論理削除するための処理-->
                       <% if exchange_comment.is_deleted == true %>
                         <td class="text-danger">削除済み</td>
                       <% else %>
-                        <%= form_with model: ExchangeComment.new, url: admin_exchange_exchange_comment_path(@exchange, exchange_comment), method: :patch, local: true do |f| %>
-                          <td>
+                        <td>
+                          <%= form_with model: ExchangeComment.new, url: admin_exchange_exchange_comment_path(@exchange, exchange_comment), method: :patch, local: true do |f| %>
                             <%= f.hidden_field :is_deleted, :value => true %>
                             <%= f.submit "コメントを削除する", class: 'btn btn-sm btn-danger' %>
-                          </td>
-                        <% end %>
+                          <% end %>
+                        </td>
                       <% end %>
+                      <!--コメントを論理削除するための処理ここまで-->
                     </td>
                   </tr>
                 <% end %>

--- a/app/views/admin/facilities/_index.html.erb
+++ b/app/views/admin/facilities/_index.html.erb
@@ -1,26 +1,26 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>名称</th>
-      <th>説明</th>
       <th>ジャンル</th>
-      <th>メモ</th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% facilities.each do |facility| %>
       <tr>
-        <td><%= facility.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= facility.residence.name %></td>
+        <% end %>
         <td><%= link_to facility.name, admin_facility_path(facility) %></td>
-        <td><%= facility.description %></td>
         <% if facility.genre_id == 0 %>
           <td>(未設定)</td>
         <% else %>
           <td><%= facility.genre.name %></td>
         <% end %>
-        <td><%= facility.note %></td>
         <td>
           <%= form_with model: Reservation, url: new_admin_reservation_path, method: :get, local: true do |f| %>
             <%= f.hidden_field :facility_id, :value => facility.id %>

--- a/app/views/admin/facilities/index.html.erb
+++ b/app/views/admin/facilities/index.html.erb
@@ -7,17 +7,23 @@
       <div class="row mr-3 mb-3">
         <h2>設備一覧</h2>
         <div class="ml-auto">
-          <table><tr>
-            <%= form_with model: Facility, url: new_admin_facility_path, method: :get, local: true do |f| %>
-              <td><%=
-                f.select :residence_id,
-                options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-                required: true,
-                class: 'form-control'
-              %></td>
-              <td><%= f.submit "選択した居住地に設備を登録", class: 'btn btn-sm btn-success' %></td>
-            <% end %>
-          </tr></table>
+          <%= form_with model: Facility, url: new_admin_facility_path, method: :get, local: true do |f| %>
+            <table class="table table-borderless table-sm">
+              <tr>
+                <td class="align-middle">
+                  <%=
+                    f.select :residence_id,
+                    options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
+                    required: true,
+                    class: 'form-control'
+                  %>
+                </td>
+                <td class="align-middle">
+                  <%= f.submit "選択した居住地に設備を登録", class: 'btn btn-sm btn-success' %>
+                </td>
+              </tr>
+            </table>
+          <% end %>
         </div>
       </div>
       <div class="container">

--- a/app/views/admin/genres/_index.html.erb
+++ b/app/views/admin/genres/_index.html.erb
@@ -1,7 +1,9 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th style="width: 30%">所在地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th style="width: 30%">所在地</th>
+      <% end %>
       <th>ジャンル名</th>
     </tr>
   </thead>
@@ -9,7 +11,9 @@
     <% genres.each do |genre| %>
       <tr>
         <% if genre.is_deleted == false %>
-          <td><%= genre.residence.name %></td>
+          <% if controller.action_name != "residence_search" %>
+            <td><%= genre.residence.name %></td>
+          <% end %>
           <td><%= genre.name %></td>
           <td class="table-borderless text-center"><%= link_to "編集する", edit_admin_genre_path(genre), class: 'btn btn-sm btn-success' %></td>
           <%= form_with model: Genre.new, url: admin_genre_path(genre), method: :patch, local: true do |f| %>

--- a/app/views/admin/lost_items/_form.html.erb
+++ b/app/views/admin/lost_items/_form.html.erb
@@ -20,10 +20,10 @@
                   <label for="image_ids_<%= image.id %>" >
                     <%= image_tag image, width: '100px' %>
                   </label>
-                <% end %>
+                <% end %><br>
+                <span class="text-info">削除したい画像にチェックを付けてください</span>
               </td>
             </tr>
-            <span class="text-info">削除したい画像にチェックを付けてください</span>
           <% end %>
           <tr>
             <td>写真</td>

--- a/app/views/admin/lost_items/_index.html.erb
+++ b/app/views/admin/lost_items/_index.html.erb
@@ -1,32 +1,30 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>作成者</th>
       <th>品名</th>
-      <th>説明</th>
-      <th>拾った場所</th>
-      <th>拾った日時</th>
-      <th>保管場所</th>
-      <th>掲載期限</th>
-      <th style="width:13%">保管状況</th>
+      <th>場所</th>
+      <th>日時</th>
+      <th style="width:13%">状況</th>
     </tr>
   </thead>
   <tbody>
     <% lost_items.each do |lost_item| %>
       <tr>
-        <td><%= lost_item.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= lost_item.residence.name %></td>
+        <% end %>
         <% if lost_item.member_id == 0 %>
           <td>管理人</td>
         <% else %>
           <td><%= lost_item.member.name %></td>
         <% end %>
         <td><%= link_to lost_item.name, admin_lost_item_path(lost_item) %></td>
-        <td><%= lost_item.description %></td>
         <td><%= lost_item.picked_up_location %></td>
         <td><%= l lost_item.picked_up_at %></td>
-        <td><%= lost_item.storage_location %></td>
-        <td><%= l lost_item.deadline %></td>
         <% if lost_item.is_finished == false %>
           <td class="text-success text-center">保管中</td>
         <% else %>

--- a/app/views/admin/lost_items/index.html.erb
+++ b/app/views/admin/lost_items/index.html.erb
@@ -7,18 +7,24 @@
       <div class="row mb-3 mr-3">
         <h2>落とし物一覧</h2>
         <div class="ml-auto">
-          <table><tr>
-            <%= form_with model: LostItem, url: new_admin_lost_item_path, method: :get, local: true do |f| %>
-              <td><%=
-                f.select :residence_id,
-                options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
-                required: true,
-                class: 'form-control'
-              %></td>
-              <td><%= f.submit "選択した居住地に落とし物を登録", class: 'btn btn-sm btn-success' %></td>
-            <% end %>
-            </tr></table>
-          </div>
+          <%= form_with model: LostItem, url: new_admin_lost_item_path, method: :get, local: true do |f| %>
+            <table class="table table-borderless table-sm">
+              <tr>
+                <td class="align-middle">
+                  <%=
+                    f.select :residence_id,
+                    options_from_collection_for_select(current_admin.residences, :id, :name), {prompt: "選択してください"},
+                    required: true,
+                    class: 'form-control'
+                  %>
+                </td>
+                <td class="align-middle">
+                  <%= f.submit "選択した居住地に落とし物を登録", class: 'btn btn-sm btn-success' %>
+                </td>
+              </tr>
+            </table>
+          <% end %>
+        </div>
       </div>
       <div class="container">
         <div class="ml-3">

--- a/app/views/admin/lost_items/show.html.erb
+++ b/app/views/admin/lost_items/show.html.erb
@@ -7,6 +7,7 @@
       <div class="container">
         <div class="offset-1">
           <table class='table table-borderless'>
+            <tr><th>居住地</th><td><%= @lost_item.residence.name %></td></tr>
             <tr>
               <th>画像</th>
               <td>
@@ -27,7 +28,6 @@
                 <td><%= @lost_item.member.name %></td>
               <% end %>
             </tr>
-            <tr><th>居住地</th><td><%= @lost_item.residence.name %></td></tr>
             <tr><th>落とし物名</th><td><%= @lost_item.name %></td></tr>
             <tr><th>説明</th><td><%= @lost_item.description %></td></tr>
             <tr><th>拾った場所</th><td><%= @lost_item.picked_up_location %></td></tr>
@@ -53,7 +53,7 @@
           </div>
 
           <!--コメント表示用の記述-->
-          <div class="col-6 mt-5">
+          <div class="mt-5">
             <div class="row mb-3 d-flex align-items-center">
               <h4>コメント</h4>&emsp;
               <span class="text-primary font-weight-bold"><%= @lost_item_comments.count %>件</span>
@@ -69,12 +69,12 @@
                       <% if lost_item_comment.is_deleted == true %>
                         <td class="text-danger">削除済み</td>
                       <% else %>
-                        <%= form_with model: LostItemComment.new, url: admin_lost_item_lost_item_comment_path(@lost_item, lost_item_comment), method: :patch, local: true do |f| %>
-                          <td>
+                        <td>
+                          <%= form_with model: LostItemComment.new, url: admin_lost_item_lost_item_comment_path(@lost_item, lost_item_comment), method: :patch, local: true do |f| %>
                             <%= f.hidden_field :is_deleted, :value => true %>
                             <%= f.submit "コメントを削除する", class: 'btn btn-sm btn-danger' %>
-                          </td>
-                        <% end %>
+                          <% end %>
+                        </td>
                       <% end %>
                       <!--コメントを論理削除するための処理ここまで-->
                     </td>

--- a/app/views/admin/members/_index.html.erb
+++ b/app/views/admin/members/_index.html.erb
@@ -2,7 +2,9 @@
   <thead>
     <tr>
       <th>名前</th>
-      <th>居住地</th>
+      <% if controller.action_name != "residence_search" %>
+        <th>居住地</th>
+      <% end %>
       <th>部屋番号</th>
     </tr>
   </thead>
@@ -10,7 +12,9 @@
     <% members.each do |member| %>
       <tr>
         <td><%= link_to member.name, admin_member_path(member) %></td>
-        <td><%= member.residence.name %></td>
+        <% if controller.action_name != "residence_search" %>
+          <td><%= member.residence.name %></td>
+        <% end %>
         <td><%= member.house_address %></td>
       </tr>
     <% end %>

--- a/app/views/admin/reservations/_index.html.erb
+++ b/app/views/admin/reservations/_index.html.erb
@@ -2,7 +2,9 @@
   <thead>
     <tr>
       <% if controller.controller_name == "reservations" %>
-        <th>居住地</th>
+        <% if controller.action_name != "residence_search" %>
+          <th>居住地</th>
+        <% end %>
         <th>予約品・設備</th>
       <% end %>
       <th>日程</th>
@@ -13,7 +15,9 @@
     <% reservations.each do |reservation| %>
       <tr>
         <% if controller.controller_name == "reservations" %>
-          <td><%= reservation.residence.name %></td>
+          <% if controller.action_name != "residence_search" %>
+            <td><%= reservation.residence.name %></td>
+          <% end %>
           <% if reservation.equipment_id.present? %>
             <td><%= link_to reservation.equipment.name, admin_equipment_path(reservation.equipment) %></td>
           <% elsif reservation.facility_id.present? %>

--- a/app/views/admin/searches/_search.html.erb
+++ b/app/views/admin/searches/_search.html.erb
@@ -3,7 +3,7 @@
     <h2>掲示板</h2>
   </div>
   <div class="ml-3">
-    <%= render 'admin/boards/index', boards: boards %>
+    <%= render 'admin/boards/index', boards: boards, reads: reads %>
   </div>
 <% end %>
 

--- a/app/views/admin/searches/search_result.html.erb
+++ b/app/views/admin/searches/search_result.html.erb
@@ -10,6 +10,7 @@
     <div class="ml-3">
       <%= render 'admin/searches/search',
         boards: @boards,
+        reads: @reads,
         communities: @communities,
         events: @events,
         exchanges: @exchanges,

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -16,7 +16,7 @@
       <%= link_to "イベント", admin_events_path, class: "nav-link text-light" %>
     </li>
     <li class="nav-item mr-3">
-      <%= link_to "譲り合い", admin_exchanges_path, class: "nav-link text-light" %>
+      <%= link_to "ゆずりあい", admin_exchanges_path, class: "nav-link text-light" %>
     </li>
     <li class="nav-item mr-3">
       <%= link_to "備品", admin_equipments_path, class: "nav-link text-light" %>

--- a/app/views/public/boards/_index.html.erb
+++ b/app/views/public/boards/_index.html.erb
@@ -1,7 +1,6 @@
 <table class='table table-borderless table-hover'>
   <thead>
     <tr>
-      <th style="width:5%"></th>
       <th style="width:40%">タイトル</th>
       <th style="width:15%">作成者</th>
       <th>作成日時</th>
@@ -12,9 +11,9 @@
   <tbody>
     <% boards.each do |board| %>
       <% if Read.find_by(board_id: board.id , member_id: current_member.id).present? %>
-        <tr style="background-color:#EEEEEE">
-          <td class="text-secondary">既読</td>
-          <td><%= link_to board.name.truncate(40), public_board_path(board) %></td>
+        <tr class="index_tr", style="background-color:#EEEEEE" data-href="/public/boards/<%= board.id%>">
+          <td><%= board.name.truncate(40) %>
+          <span class="text-secondary">(既読)</span></td>
           <% if board.member_id == 0 %>
             <td>管理人</td>
           <% elsif board.member.present? %>
@@ -38,9 +37,8 @@
           <% end %>
         </tr>
       <% else %>
-        <tr>
-          <td></td>
-          <td><%= link_to board.name.truncate(40), public_board_path(board) %></td>
+        <tr class="board_index_tr" data-href="/public/boards/<%= board.id%>">
+          <td><%= board.name.truncate(40) %></td>
           <% if board.member_id == 0 %>
             <td>管理人</td>
           <% elsif board.member.present? %>

--- a/app/views/public/boards/_index.html.erb
+++ b/app/views/public/boards/_index.html.erb
@@ -11,7 +11,7 @@
   <tbody>
     <% boards.each do |board| %>
       <% if Read.find_by(board_id: board.id , member_id: current_member.id).present? %>
-        <tr class="index_tr", style="background-color:#EEEEEE" data-href="/public/boards/<%= board.id%>">
+        <tr class="index_tr", style="background-color:#EEEEEE" data-href="/public/boards/<%= board.id %>">
           <td><%= board.name.truncate(40) %>
           <span class="text-secondary">(既読)</span></td>
           <% if board.member_id == 0 %>
@@ -37,7 +37,7 @@
           <% end %>
         </tr>
       <% else %>
-        <tr class="board_index_tr" data-href="/public/boards/<%= board.id%>">
+        <tr class="index_tr" data-href="/public/boards/<%= board.id%>">
           <td><%= board.name.truncate(40) %></td>
           <% if board.member_id == 0 %>
             <td>管理人</td>

--- a/app/views/public/boards/index.html.erb
+++ b/app/views/public/boards/index.html.erb
@@ -1,11 +1,11 @@
 <div class='container p-5 px-sm-0'>
-  <div class="row mr-3 mb-3">
-    <h2>掲示板一覧</h2>
-    <div class="ml-auto">
-      <%= link_to "掲示板に新しく投稿", new_public_board_path, class: 'btn btn-sm btn-success' %>
+  <div class='col-md-12'>
+    <div class="row mr-3 mb-3">
+      <h2>掲示板一覧</h2>
+      <div class="ml-auto mr-3">
+        <%= link_to "掲示板に新しく投稿", new_public_board_path, class: 'btn btn-success' %>
+      </div>
     </div>
-  </div>
-  <div class="container">
     <div class="ml-3">
       <div class="tabs">
         <ul class="nav nav-tabs">

--- a/app/views/public/circular_members/index.html.erb
+++ b/app/views/public/circular_members/index.html.erb
@@ -1,32 +1,32 @@
 <div class='container p-5 px-sm-0'>
-    <div class='col-md-10 offset-md-1'>
-      <div class="row ml-5 mb-3">
-        <h2>回覧メンバー編集</h2>
-      </div>
-      <div class="ml-5 mb-3">
-        <table class='table table-borderless'>
-          <% @members.each do |member| %>
-            <tr>
-              <% if member != @board.member %>
-                <td style="width:30%"><%= member.name %></td>
-                <% if @board.circular_members.exists?(member_id: member.id) %>
-                  <td><%= link_to "削除", public_board_circular_member_path(@board.id, member.id), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                <% else %>
+  <div class='col-md-10 offset-md-1'>
+    <div class="row ml-5 mb-3">
+      <h2>回覧メンバー編集</h2>
+    </div>
+    <div class="ml-5 mb-3">
+      <table class='table table-borderless'>
+        <% @members.each do |member| %>
+          <tr>
+            <% if member != @board.member %>
+              <td style="width:30%"><%= member.name %></td>
+              <% if @board.circular_members.exists?(member_id: member.id) %>
+                <td><%= link_to "削除", public_board_circular_member_path(@board.id, member.id), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+              <% else %>
+                <td>
                   <%= form_with model:@circular_member, url: public_board_circular_members_path(@board), local: true do |f| %>
-                    <td>
-                      <%= f.hidden_field :board_id, :value => params[:board_id] %>
-                      <%= f.hidden_field :member_id, :value => member.id %>
-                      <%= f.submit "追加", class: 'btn btn-sm btn-success' %>
-                    </td>
+                    <%= f.hidden_field :board_id, :value => params[:board_id] %>
+                    <%= f.hidden_field :member_id, :value => member.id %>
+                    <%= f.submit "追加", class: 'btn btn-sm btn-success' %>
                   <% end %>
-                <% end %>
+                </td>
               <% end %>
-            </tr>
-          <% end %>
-        </table>
-        <div class="text-right">
-          <%= link_to "掲示板詳細へ", public_board_path(@board) %>
-        </div>
+            <% end %>
+          </tr>
+        <% end %>
+      </table>
+      <div class="text-right">
+        <%= link_to "掲示板詳細へ", public_board_path(@board) %>
       </div>
     </div>
+  </div>
 </div>

--- a/app/views/public/communities/_index.html.erb
+++ b/app/views/public/communities/_index.html.erb
@@ -9,8 +9,8 @@
   </thead>
   <tbody>
     <% communities.each do |community| %>
-      <tr class="index_tr" data-href="/public/communities/<%= community.id%>">
-        <td><%= link_to community.name, public_community_path(community) %></td>
+      <tr class="index_tr" data-href="/public/communities/<%= community.id %>">
+        <td><%= community.name %></td>
         <% if community.member.present? %>
           <td><%= community.member.name %></td>
         <% else %>

--- a/app/views/public/communities/_index.html.erb
+++ b/app/views/public/communities/_index.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-borderless'>
+<table class='table table-borderless table-hover'>
   <thead>
     <tr>
       <th>コミュニティ名</th>
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <% communities.each do |community| %>
-      <tr>
+      <tr class="index_tr" data-href="/public/communities/<%= community.id%>">
         <td><%= link_to community.name, public_community_path(community) %></td>
         <% if community.member.present? %>
           <td><%= community.member.name %></td>

--- a/app/views/public/communities/index.html.erb
+++ b/app/views/public/communities/index.html.erb
@@ -2,8 +2,8 @@
   <div class='col-md-12'>
     <div class="row mr-3 mb-3">
       <h2>コミュニティ一覧</h2>
-      <div class="ml-auto">
-        <%= link_to "新しいコミュニティを作る", new_public_community_path, class: 'btn btn-sm btn-success' %>
+      <div class="ml-auto mr-3">
+        <%= link_to "新しいコミュニティを作る", new_public_community_path, class: 'btn btn-success' %>
       </div>
     </div>
     <div class="ml-3">

--- a/app/views/public/communities/show.html.erb
+++ b/app/views/public/communities/show.html.erb
@@ -34,15 +34,15 @@
             <h4>コメント</h4>&emsp;
             <span class="text-primary font-weight-bold"><%= @community_comments.count - @community_comments.where(is_deleted: true).count %>件</span>
           </div>
-          <%= form_with model: CommunityComment.new, url: public_community_community_comments_path(@community), method: :post, local: true do |f| %>
-            <td>
+          <% if @community_member.present? %>
+            <%= form_with model: CommunityComment.new, url: public_community_community_comments_path(@community), method: :post, local: true do |f| %>
               <%= f.hidden_field :community_id, :value => @community.id %>
               <%= f.hidden_field :member_id, :value => current_member.id %>
               <%= f.text_area :comment, class: "form-control" %>
               <div class="mt-2 text-center">
                 <%= f.submit "コメントする", class: 'btn btn-sm btn-danger' %>
               </div>
-            </td>
+            <% end %>
           <% end %>
 
           <div class="mt-2">

--- a/app/views/public/community_members/index.html.erb
+++ b/app/views/public/community_members/index.html.erb
@@ -1,60 +1,60 @@
-<!--参加メンバー表示用の記述-->
-<div class="col-3">
-  <div class="row mb-3 d-flex align-items-center">
-    <h4>参加メンバー</h4>&emsp;
-    <span class="text-primary font-weight-bold"><%= @community_members.count %>人</span>
-  </div>
-  <table class='table table-borderless'>
-    <tbody>
-      <% @community_members.each do |community_member| %>
-        <tr>
-          <td style="width: 35%"><%= community_member.member.name %></td>
-          <!--管理者かどうかの確認と切り替え処理-->
-          <% if @community_members.find_by(member_id: current_member.id) && @community_member.is_admin == true  %>　　　<!--条件1　コミュニティメンバーかつ管理者権限がある場合-->
-            <% if community_member.is_admin == true %>　 　<!--条件2　表示されるメンバーが管理者かメンバーかの判別-->
-              <td class="text-danger">管理者</td>
-              <!--管理者からメンバーへの変更ボタン-->
-              <%= form_with model: CommunityMember, url: public_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+<div class='container p-5 px-sm-0'>
+  <div class='col-md-10 offset-md-1'>
+    <div class="row mb-3 d-flex align-items-center">
+      <h4>参加メンバー</h4>&emsp;
+      <span class="text-primary font-weight-bold"><%= @community_members.count %>人</span>
+    </div>
+    <table class='table table-borderless'>
+      <tbody>
+        <% @community_members.each do |community_member| %>
+          <tr>
+            <td style="width: 35%"><%= community_member.member.name %></td>
+            <!--管理者かどうかの確認と切り替え処理-->
+            <% if @community_members.find_by(member_id: current_member.id) && @community_member.is_admin == true  %>　　　<!--条件1　コミュニティメンバーかつ管理者権限がある場合-->
+              <% if community_member.is_admin == true %>　 　<!--条件2　表示されるメンバーが管理者かメンバーかの判別-->
+                <td class="text-danger">管理者</td>
+                <!--管理者からメンバーへの変更ボタン-->
                 <td>
-                  <%= f.hidden_field :is_admin, :value => false %>
-                  <%= f.submit "メンバーに変更", class: 'btn btn-sm btn-success' %>
+                  <%= form_with model: CommunityMember, url: public_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+                    <%= f.hidden_field :is_admin, :value => false %>
+                    <%= f.submit "メンバーに変更", class: 'btn btn-sm btn-success' %>
+                  <% end %>
                 </td>
-              <% end %>
-              <td></td>
-              <!--管理者からメンバーへの変更ボタンここまで-->
-            <% else %>
-              <td class="text-success">メンバー</td>
-              <!--メンバーから管理者への変更ボタン-->
-              <%= form_with model: CommunityMember, url: public_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+                <td></td>
+                <!--管理者からメンバーへの変更ボタンここまで-->
+              <% else %>
+                <td class="text-success">メンバー</td>
+                <!--メンバーから管理者への変更ボタン-->
                 <td>
-                  <%= f.hidden_field :is_admin, :value => true %>
-                  <%= f.submit "管理者に変更", class: 'btn btn-sm btn-danger' %>
+                  <%= form_with model: CommunityMember, url: public_community_community_member_path(@community, community_member), method: :patch, local: true do |f| %>
+                    <%= f.hidden_field :is_admin, :value => true %>
+                    <%= f.submit "管理者に変更", class: 'btn btn-sm btn-danger' %>
+                  <% end %>
                 </td>
-              <% end %>
-              <!--メンバーから管理者への変更ボタンここまで-->
+                <!--メンバーから管理者への変更ボタンここまで-->
 
-              <td>
-                <!--メンバーの追放ボタン(管理者のみ表示)-->
-                <%= link_to public_community_community_member_path(@community, community_member), method: :delete, class: 'btn btn-sm btn-secondary' do %>
-                  <i class="fa-solid fa-trash-can fa-2xs"></i>
-                <% end %>
-                <!--メンバーの追放ボタンここまで-->
-              </td>
-            <% end %>　 　<!--条件2　ここまで-->
-          <% else %>　    <!--条件1　コミュニティの管理者権限がなかった場合の表示ここから-->
-            <% if community_member.is_admin == true %>
-              <td class="text-danger">管理者</td>
+                <td>
+                  <!--メンバーの追放ボタン(管理者のみ表示)-->
+                  <%= link_to public_community_community_member_path(@community, community_member), method: :delete, class: 'btn btn-sm btn-secondary' do %>
+                    <i class="fa-solid fa-trash-can fa-2xs"></i>
+                  <% end %>
+                  <!--メンバーの追放ボタンここまで-->
+                </td>
+              <% end %>　 　<!--条件2　ここまで-->
+            <% else %>　    <!--条件1　コミュニティの管理者権限がなかった場合の表示ここから-->
+              <% if community_member.is_admin == true %>
+                <td class="text-danger">管理者</td>
+                <td></td>
+              <% else %>
+                <td class="text-success">メンバー</td>
+                <td></td>
+              <% end %>
               <td></td>
-            <% else %>
-              <td class="text-success">メンバー</td>
-              <td></td>
-            <% end %>
-            <td></td>
-          <% end %>　 　<!--条件1　ここまで-->
-          <!--管理者かどうかの確認と切り替え処理ここまで-->
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+            <% end %>　 　<!--条件1　ここまで-->
+            <!--管理者かどうかの確認と切り替え処理ここまで-->
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>
-<!--参加メンバー表示用の記述ここまで-->

--- a/app/views/public/equipments/_index.html.erb
+++ b/app/views/public/equipments/_index.html.erb
@@ -13,8 +13,8 @@
   </thead>
   <tbody>
     <% equipments.each do |equipment| %>
-      <tr>
-        <td><%= link_to equipment.name, public_equipment_path(equipment) %></td>
+      <tr class="index_tr" data-href="/public/equipments/<%= equipment.id %>">
+        <td><%= equipment.name %></td>
         <td><%= equipment.description %></td>
         <% if equipment.genre_id == 0 %>
           <td>(未設定)</td>

--- a/app/views/public/equipments/_index.html.erb
+++ b/app/views/public/equipments/_index.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-borderless'>
+<table class='table table-borderless table-hover'>
   <thead>
     <tr>
       <th>名称</th>

--- a/app/views/public/equipments/show.html.erb
+++ b/app/views/public/equipments/show.html.erb
@@ -2,10 +2,10 @@
   <div class='col-md-12'>
     <div class="row mr-3 mb-3">
       <h2>備品詳細</h2>
-      <div class="ml-auto">
+      <div class="ml-auto mr-3">
         <%= form_with model: Reservation, url: new_public_reservation_path, method: :get, local: true do |f| %>
           <%= f.hidden_field :equipment_id, :value => @equipment.id %>
-          <%= f.submit "予約する", class: 'btn btn-sm btn-success' %>
+          <%= f.submit "予約する", class: 'btn btn-success' %>
         <% end %>
       </div>
     </div>

--- a/app/views/public/event_members/index.html.erb
+++ b/app/views/public/event_members/index.html.erb
@@ -28,8 +28,10 @@
             <tr>
               <% if @event.event_members.where(member_id: member.id).present? %>
                 <% if @event.event_members.find_by(member_id: member.id).is_approved == false %>
-                  <td style="width:30%"><%= member.name %></td>
-                  <td class="text-success">招待中</td>
+                  <td style="width:30%">
+                    <%= member.name %>
+                    <span class="text-success">招待中</span>
+                  </td>
                   <% if @event.member == current_member %>
                     <td><%= link_to "招待を取り消す", public_event_event_member_quit_invite_path(@event.id, @event.event_members.find_by(member_id: member.id)), method: :delete, class: "btn btn-secondary" %></td>
                   <% else %>
@@ -38,7 +40,6 @@
                 <% end %>
               <% else %>
                 <td style="width:30%"><%= member.name %></td>
-                <td></td>
                 <% if @event.member == current_member %>
                   <td>
                     <%= form_with model:EventMember.new, url: public_event_event_members_path(@event), local: true do |f| %>

--- a/app/views/public/events/_index.html.erb
+++ b/app/views/public/events/_index.html.erb
@@ -1,9 +1,8 @@
-<table class='table table-borderless'>
+<table class='table table-borderless table-hover'>
   <thead>
     <tr>
       <th>イベント名</th>
       <th>作成者</th>
-      <th>概要</th>
       <th>開催日時</th>
       <th>開催場所</th>
     </tr>
@@ -28,7 +27,6 @@
         <% else %>
           <td>退会済み会員</td>
         <% end %>
-        <td><%= event.description %></td>
         <td><%= l event.started_at %> ~ <%= l event.finished_at %></td>
         <td><%= event.venue %></td>
       </tr>

--- a/app/views/public/events/_index.html.erb
+++ b/app/views/public/events/_index.html.erb
@@ -9,9 +9,9 @@
   </thead>
   <tbody>
     <% events.each do |event| %>
-      <tr>
+      <tr class="index_tr" data-href="/public/events/<%= event.id %>">
         <td>
-          <%= link_to event.name, public_event_path(event) %>
+          <%= event.name %>
           <%
             if event.event_members.find_by(member_id: current_member.id).present? &&
             event.event_members.find_by(member_id: current_member.id).is_approved == false &&

--- a/app/views/public/events/index.html.erb
+++ b/app/views/public/events/index.html.erb
@@ -1,11 +1,11 @@
 <div class='container p-5 px-sm-0'>
-  <div class="row mr-3 mb-3">
-    <h2>イベント一覧</h2>
-    <div class="ml-auto">
-      <%= link_to "イベントを作成", new_public_event_path, class: 'btn btn-sm btn-success' %>
+  <div class='col-md-12'>
+    <div class="row mr-3 mb-3">
+      <h2>イベント一覧</h2>
+      <div class="ml-auto mr-3">
+        <%= link_to "イベントを作成", new_public_event_path, class: 'btn btn-success' %>
+      </div>
     </div>
-  </div>
-  <div class="container">
     <div class="ml-3">
       <div class="tabs">
         <ul class="nav nav-tabs">

--- a/app/views/public/events/show.html.erb
+++ b/app/views/public/events/show.html.erb
@@ -1,7 +1,7 @@
 <div class='container p-5 px-sm-0'>
   <div class="row ml-5 mb-3">
     <h2>イベント詳細</h2>
-    <div class="ml-auto">
+    <div class="ml-auto mr-3">
       <%= render 'public/events/join', event: @event, event_member: @event_member %>
     </div>
   </div>

--- a/app/views/public/exchanges/_comment.html.erb
+++ b/app/views/public/exchanges/_comment.html.erb
@@ -2,16 +2,16 @@
   <h4>コメント</h4>&emsp;
   <span class="text-primary font-weight-bold"><%= exchange_comments.count - exchange_comments.where(is_deleted: true).count %>件</span>
 </div>
-<%= form_with model: ExchangeComment.new, url: public_exchange_exchange_comments_path(exchange), method: :post, local: true do |f| %>
-  <td>
+<div>
+  <%= form_with model: ExchangeComment.new, url: public_exchange_exchange_comments_path(exchange), method: :post, local: true do |f| %>
     <%= f.hidden_field :exchange_id, :value => @exchange.id %>
     <%= f.hidden_field :member_id, :value => current_member.id %>
     <%= f.text_area :comment, class: "form-control" %>
     <div class="mt-2 text-center">
       <%= f.submit "コメントする", class: 'btn btn-sm btn-danger' %>
     </div>
-  </td>
-<% end %>
+  <% end %>
+</div>
 
 <div class="mt-2">
   <% exchange_comments.each do |comment| %>
@@ -41,10 +41,10 @@
       </div>
     <% end %>
     <!--コメントを論理削除するための処理-->
-    <% if comment.member == exchange.member %>
+    <% if current_member == exchange.member %>
       <% if comment.is_deleted == false %>
         <%= form_with model: ExchangeComment, url: public_exchange_exchange_comment_path(exchange, comment), method: :patch, local: true do |f| %>
-          <div>
+          <div class="text-right">
             <%= f.hidden_field :is_deleted, :value => true %>
             <%= button_tag type: "submit", class: 'btn btn-sm' do %>
               <i class="fa-solid fa-trash"></i>

--- a/app/views/public/exchanges/_index.html.erb
+++ b/app/views/public/exchanges/_index.html.erb
@@ -4,9 +4,7 @@
       <th>画像</th>
       <th>落とし物名</th>
       <th>投稿者</th>
-      <th>説明</th>
       <th>費用</th>
-      <th>掲載期限</th>
       <th>募集状況</th>
     </tr>
   </thead>
@@ -20,15 +18,13 @@
             <% end %>
           <% end %>
         </td>
-        <td><%= link_to exchange.name, public_exchange_path(exchange) %></td>
-        <td><%= exchange.member.name %></td>
-        <td><%= exchange.description %></td>
-        <td><%= exchange.price.to_s(:delimited) %>円</td>
-        <td><%= l exchange.deadline %></td>
+        <td class="align-middle"><%= link_to exchange.name, public_exchange_path(exchange) %></td>
+        <td class="align-middle"><%= exchange.member.name %></td>
+        <td class="align-middle"><%= exchange.price.to_s(:delimited) %>円</td>
         <% if exchange.is_finished == false %>
-          <td class="text-success">募集中</td>
+          <td class="text-success align-middle">募集中</td>
         <% else %>
-          <td class="text-secondary">募集終了</td>
+          <td class="text-secondary align-middle">募集終了</td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/public/exchanges/_index.html.erb
+++ b/app/views/public/exchanges/_index.html.erb
@@ -10,7 +10,7 @@
   </thead>
   <tbody>
     <% exchanges.each do |exchange| %>
-      <tr>
+      <tr class="index_tr" data-href="/public/exchanges/<%= exchange.id %>">
         <td>
           <% if exchange.exchange_item_images.attached? %>
             <% exchange.exchange_item_images.limit(1).each do |image| %>
@@ -18,7 +18,7 @@
             <% end %>
           <% end %>
         </td>
-        <td class="align-middle"><%= link_to exchange.name, public_exchange_path(exchange) %></td>
+        <td class="align-middle"><%= exchange.name %></td>
         <td class="align-middle"><%= exchange.member.name %></td>
         <td class="align-middle"><%= exchange.price.to_s(:delimited) %>円</td>
         <% if exchange.is_finished == false %>

--- a/app/views/public/exchanges/index.html.erb
+++ b/app/views/public/exchanges/index.html.erb
@@ -2,8 +2,8 @@
   <div class='col-md-12'>
     <div class="row mr-3 mb-3">
       <h2>ゆずりあい一覧</h2>
-      <div class="ml-auto">
-        <%= link_to "ゆずりあいを登録する", new_public_exchange_path, class: 'btn btn-sm btn-success' %>
+      <div class="ml-auto mr-3">
+        <%= link_to "ゆずりあいを登録する", new_public_exchange_path, class: 'btn btn-success' %>
       </div>
     </div>
     <div class="ml-3">

--- a/app/views/public/facilities/_index.html.erb
+++ b/app/views/public/facilities/_index.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-borderless'>
+<table class='table table-borderlesstable-hover'>
   <thead>
     <tr>
       <th>名称</th>

--- a/app/views/public/facilities/_index.html.erb
+++ b/app/views/public/facilities/_index.html.erb
@@ -10,8 +10,8 @@
   </thead>
   <tbody>
     <% facilities.each do |facility| %>
-      <tr>
-        <td><%= link_to facility.name, public_facility_path(facility) %></td>
+      <tr class="index_tr" data-href="/public/facilities/<%= facility.id %>">
+        <td><%= facility.name %></td>
         <td><%= facility.description %></td>
         <% if facility.genre_id == 0 %>
           <td>(未設定)</td>

--- a/app/views/public/facilities/show.html.erb
+++ b/app/views/public/facilities/show.html.erb
@@ -2,10 +2,10 @@
   <div class='col-md-12'>
     <div class="row ml-5 mb-3">
       <h2>設備詳細</h2>
-      <div class="ml-auto">
+      <div class="ml-auto mr-3">
         <%= form_with model: Reservation, url: new_public_reservation_path, method: :get, local: true do |f| %>
           <%= f.hidden_field :facility_id, :value => @facility.id %>
-          <%= f.submit "予約する", class: 'btn btn-sm btn-success' %>
+          <%= f.submit "予約する", class: 'btn btn-success' %>
         <% end %>
       </div>
     </div>

--- a/app/views/public/lost_items/_comment.html.erb
+++ b/app/views/public/lost_items/_comment.html.erb
@@ -2,16 +2,16 @@
   <h4>コメント</h4>&emsp;
   <span class="text-primary font-weight-bold"><%= lost_item_comments.count - lost_item_comments.where(is_deleted: true).count %>件</span>
 </div>
-<%= form_with model: LostItemComment.new, url: public_lost_item_lost_item_comments_path(lost_item), method: :post, local: true do |f| %>
-  <td>
+<div>
+  <%= form_with model: LostItemComment.new, url: public_lost_item_lost_item_comments_path(lost_item), method: :post, local: true do |f| %>
     <%= f.hidden_field :lost_item_id, :value => @lost_item.id %>
     <%= f.hidden_field :member_id, :value => current_member.id %>
     <%= f.text_area :comment, class: "form-control" %>
     <div class="mt-2 text-center">
       <%= f.submit "コメントする", class: 'btn btn-sm btn-danger' %>
     </div>
-  </td>
-<% end %>
+  <% end %>
+</div>
 
 <div class="mt-2">
   <% lost_item_comments.each do |comment| %>
@@ -41,10 +41,10 @@
       </div>
     <% end %>
     <!--コメントを論理削除するための処理-->
-    <% if comment.member == lost_item.member %>
+    <% if current_member == lost_item.member %>
       <% if comment.is_deleted == false %>
         <%= form_with model: LostItemComment, url: public_lost_item_lost_item_comment_path(lost_item, comment), method: :patch, local: true do |f| %>
-          <div>
+          <div class="text-right">
             <%= f.hidden_field :is_deleted, :value => true %>
             <%= button_tag type: "submit", class: 'btn btn-sm' do %>
               <i class="fa-solid fa-trash"></i>

--- a/app/views/public/lost_items/_index.html.erb
+++ b/app/views/public/lost_items/_index.html.erb
@@ -4,11 +4,8 @@
       <th>画像</th>
       <th>落とし物名</th>
       <th>投稿者</th>
-      <th>説明</th>
-      <th>拾った場所</th>
-      <th>拾った日時</th>
-      <th>保管場所</th>
-      <th>掲載期限</th>
+      <th>場所</th>
+      <th>日時</th>
       <th>保管状況</th>
     </tr>
   </thead>
@@ -22,23 +19,20 @@
             <% end %>
           <% end %>
         </td>
-        <td><%= link_to lost_item.name, public_lost_item_path(lost_item) %></td>
+        <td class="align-middle"><%= link_to lost_item.name, public_lost_item_path(lost_item) %></td>
         <% if lost_item.member_id == 0 %>
           <td>管理人</td>
         <% elsif lost_item.member.present? %>
-          <td><%= lost_item.member.name %></td>
+          <td class="align-middle"><%= lost_item.member.name %></td>
         <% else %>
           <td class="text-secondary">退会済み会員</td>
         <% end %>
-        <td><%= lost_item.description %></td>
-        <td><%= lost_item.picked_up_location %></td>
-        <td><%= l lost_item.picked_up_at %></td>
-        <td><%= lost_item.storage_location %></td>
-        <td><%= l lost_item.deadline %></td>
+        <td class="align-middle"><%= lost_item.picked_up_location %></td>
+        <td class="align-middle"><%= l lost_item.picked_up_at %></td>
         <% if lost_item.is_finished == false %>
-          <td class="text-success">保管中</td>
+          <td class="text-success align-middle">保管中</td>
         <% else %>
-          <td class="text-secondary">保管終了</td>
+          <td class="text-secondary align-middle">保管終了</td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/public/lost_items/_index.html.erb
+++ b/app/views/public/lost_items/_index.html.erb
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <% lost_items.each do |lost_item| %>
-      <tr>
+      <tr class="index_tr" data-href="/public/lost_items/<%= lost_item.id %>">
         <td>
           <% if lost_item.lost_item_images.attached? %>
             <% lost_item.lost_item_images.limit(1).each do |image| %>
@@ -19,7 +19,7 @@
             <% end %>
           <% end %>
         </td>
-        <td class="align-middle"><%= link_to lost_item.name, public_lost_item_path(lost_item) %></td>
+        <td class="align-middle"><%= lost_item.name %></td>
         <% if lost_item.member_id == 0 %>
           <td>管理人</td>
         <% elsif lost_item.member.present? %>

--- a/app/views/public/lost_items/index.html.erb
+++ b/app/views/public/lost_items/index.html.erb
@@ -2,8 +2,8 @@
   <div class='col-md-12'>
     <div class="row mr-3 mb-3">
       <h2>落とし物一覧</h2>
-      <div class="ml-auto">
-        <%= link_to "落とし物を登録する", new_public_lost_item_path, class: 'btn btn-sm btn-success' %>
+      <div class="ml-auto mr-3">
+        <%= link_to "落とし物を登録する", new_public_lost_item_path, class: 'btn btn-success' %>
       </div>
     </div>
     <div class="ml-3">

--- a/app/views/public/members/_index.html.erb
+++ b/app/views/public/members/_index.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-borderless'>
+<table class='table table-borderless table-hover'>
   <thead>
     <tr>
       <th>名前</th>

--- a/app/views/public/plans/_index.html.erb
+++ b/app/views/public/plans/_index.html.erb
@@ -8,8 +8,8 @@
   </thead>
   <tbody>
     <% plans.each do |plan| %>
-      <tr>
-        <td><%= link_to plan.subject, public_plan_path(plan) %></td>
+      <tr class="index_tr" data-href="/public/plans/<%= plan.id %>">
+        <td><%= plan.subject %></td>
         <td><%= l plan.started_at %> ~ <%= l plan.finished_at %></td>
         <td><%= plan.venue %></td>
       </tr>

--- a/app/views/public/plans/_index.html.erb
+++ b/app/views/public/plans/_index.html.erb
@@ -1,10 +1,9 @@
-<table class='table table-borderless'>
+<table class='table table-borderless  table-hover'>
   <thead>
     <tr>
       <th>予定名</th>
       <th>日程</th>
       <th>場所</th>
-      <th>メモ</th>
     </tr>
   </thead>
   <tbody>
@@ -13,7 +12,6 @@
         <td><%= link_to plan.subject, public_plan_path(plan) %></td>
         <td><%= l plan.started_at %> ~ <%= l plan.finished_at %></td>
         <td><%= plan.venue %></td>
-        <td><%= plan.memo %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/public/plans/index.html.erb
+++ b/app/views/public/plans/index.html.erb
@@ -1,11 +1,11 @@
 <div class='container p-5 px-sm-0'>
-  <div class="row mr-3 mb-3">
-    <h2>予定一覧</h2>
-    <div class="ml-auto">
-      <%= link_to "予定を追加", new_public_plan_path, class: 'btn btn-sm btn-success' %>
+  <div class='col-md-12'>
+    <div class="row mr-3 mb-3">
+      <h2>予定一覧</h2>
+      <div class="ml-auto mr-3">
+        <%= link_to "予定を追加", new_public_plan_path, class: 'btn btn-success' %>
+      </div>
     </div>
-  </div>
-  <div class="container">
     <div class="ml-3">
       <div class="tabs">
         <ul class="nav nav-tabs">

--- a/app/views/public/reservations/_index.html.erb
+++ b/app/views/public/reservations/_index.html.erb
@@ -10,19 +10,15 @@
   </thead>
   <tbody>
     <% reservations.each do |reservation| %>
-      <tr>
+      <tr class="index_tr" data-href="/public/reservations/<%= reservation.id %>">
         <% if controller.controller_name == "reservations" %>
           <% if reservation.equipment_id.present? %>
-            <td><%= link_to reservation.equipment.name, public_equipment_path(reservation.equipment) %></td>
+            <td><%= reservation.equipment.name %></td>
           <% elsif reservation.facility_id.present? %>
-            <td><%= link_to reservation.facility.name, public_facility_path(reservation.facility)%></td>
+            <td><%= reservation.facility.name %></td>
           <% end %>
         <% end %>
-        <td>
-          <%= link_to public_reservation_path(reservation) do %>
-            <%= l reservation.started_at %> ~ <%= l reservation.finished_at %>
-          <% end %>
-        </td>
+        <td><%= l reservation.started_at %> ~ <%= l reservation.finished_at %></td>
         <% if reservation.member_id == 0 %>
           <td>管理人</td>
         <% else %>

--- a/app/views/public/reservations/_index.html.erb
+++ b/app/views/public/reservations/_index.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-borderless'>
+<table class='table table-borderless table-hover'>
   <thead>
     <tr>
       <% if controller.controller_name == "reservations" %>

--- a/app/views/public/reservations/index.html.erb
+++ b/app/views/public/reservations/index.html.erb
@@ -2,8 +2,8 @@
   <div class='col-md-12'>
     <div class="row mr-3 mb-3">
       <h2>予約一覧</h2>
-      <div class="ml-auto">
-        <%= link_to "予約する",public_reservations_select_path, class: 'btn btn-sm btn-success' %>
+      <div class="ml-auto mr-3">
+        <%= link_to "予約する",public_reservations_select_path, class: 'btn btn-success' %>
       </div>
     </div>
     <div class="ml-3">

--- a/app/views/public/reservations/show.html.erb
+++ b/app/views/public/reservations/show.html.erb
@@ -7,9 +7,21 @@
           <div class="offset-1">
             <table class='table table-borderless'>
               <% if @reservation.equipment_id.present? %>
-                <tr><th>予約品</th><td><%= image_tag @reservation.equipment.get_equipment_image %><%= @reservation.equipment.name %></td></tr>
+                <tr>
+                  <th>予約品</th>
+                  <td>
+                    <%= image_tag @reservation.equipment.get_equipment_image %>
+                    <%= link_to @reservation.equipment.name, public_equipment_path(@reservation.equipment) %>
+                  </td>
+                </tr>
               <% elsif @reservation.facility_id.present? %>
-                <tr><th>予約場所</th><td><%= image_tag @reservation.facility.get_facility_image %><%= @reservation.facility.name %></td></tr>
+                <tr>
+                  <th>予約場所</th>
+                  <td>
+                    <%= image_tag @reservation.facility.get_facility_image %>
+                    <%= link_to @reservation.facility.name, public_facility_path(@reservation.facility) %>
+                  </td>
+                </tr>
               <% end %>
               <% if @reservation.member_id == 0 %>
                 <tr><th>予約者</th><td>管理人</td></tr>

--- a/app/views/public/residences/_index.html.erb
+++ b/app/views/public/residences/_index.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-borderless'>
+<table class='table table-borderless table-hover'>
   <thead>
     <tr>
       <th>名称</th>

--- a/app/views/public/searches/_search.html.erb
+++ b/app/views/public/searches/_search.html.erb
@@ -1,6 +1,6 @@
 <% if boards.present? %>
   <div class="mb-3">
-    <h2>掲示板</h2>
+    <h2 class="border-bottom border-dark">掲示板</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/boards/index', boards: boards, reads: reads %>
@@ -9,7 +9,7 @@
 
 <% if communities.present? %>
   <div class="mb-3">
-    <h2>コミュニティ</h2>
+    <h2 class="border-bottom border-dark">コミュニティ</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/communities/index', communities: communities %>
@@ -18,7 +18,7 @@
 
 <% if events.present? %>
   <div class="mb-3">
-    <h2>イベント</h2>
+    <h2 class="border-bottom border-dark">イベント</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/events/index', events: events %>
@@ -27,7 +27,7 @@
 
 <% if exchanges.present? %>
   <div class="mb-3">
-    <h2>ゆずりあい</h2>
+    <h2 class="border-bottom border-dark">ゆずりあい</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/exchanges/index', exchanges: exchanges %>
@@ -36,7 +36,7 @@
 
 <% if lost_items.present? %>
   <div class="mb-3">
-    <h2>落とし物</h2>
+    <h2 class="border-bottom border-dark">落とし物</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/lost_items/index', lost_items: lost_items %>
@@ -45,7 +45,7 @@
 
 <% if equipments.present? %>
   <div class="mb-3">
-    <h2>備品</h2>
+    <h2 class="border-bottom border-dark">備品</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/equipments/index', equipments: equipments %>
@@ -54,7 +54,7 @@
 
 <% if facilities.present? %>
   <div class="mb-3">
-    <h2>設備</h2>
+    <h2 class="border-bottom border-dark">設備</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/facilities/index', facilities: facilities %>
@@ -63,7 +63,7 @@
 
 <% if members.present? %>
   <div class="mb-3">
-    <h2>会員</h2>
+    <h2 class="border-bottom border-dark">会員</h2>
   </div>
   <div class="ml-3">
     <%= render 'public/members/index', members: members %>


### PR DESCRIPTION
・管理側
フォームの居住地セレクトフォーム削除
表示順調整
フォーム関連ボタンの挙動修正（div,tdタブをform_withの外に）
residenceモデルにバリデーション追加
一覧の表示内容調整

・会員側
テーブルのホバー設定
リンクのクリック箇所を列全体に変更
一覧の表示内容調整
検索結果画面微調整