### PR TITLE
会員側掲示板機能非同期化

### DIFF
--- a/app/controllers/admin/circular_members_controller.rb
+++ b/app/controllers/admin/circular_members_controller.rb
@@ -34,7 +34,7 @@ class Admin::CircularMembersController < ApplicationController
 
   def destroy
     @board = Board.find(params[:board_id])
-    circular_member = @board.circular_members.find_by(member_id: params[:id])
+    circular_member = @board.circular_members.find_by(member_id: params[:member_id])
     @residence_members = @board.residence.members
     @circular_member = CircularMember.new
     unless circular_member.destroy

--- a/app/controllers/admin/circular_members_controller.rb
+++ b/app/controllers/admin/circular_members_controller.rb
@@ -5,7 +5,6 @@ class Admin::CircularMembersController < ApplicationController
   def index
     @board = Board.find(params[:board_id])
     @residence_members = @board.residence.members
-    @circular_member = CircularMember.new
   end
 
   def create
@@ -36,7 +35,6 @@ class Admin::CircularMembersController < ApplicationController
     @board = Board.find(params[:board_id])
     circular_member = @board.circular_members.find_by(member_id: params[:member_id])
     @residence_members = @board.residence.members
-    @circular_member = CircularMember.new
     unless circular_member.destroy
       flash.now[:alert] = "回覧メンバーの削除に失敗しました。"
       render "index"

--- a/app/controllers/public/boards_controller.rb
+++ b/app/controllers/public/boards_controller.rb
@@ -17,7 +17,6 @@ class Public::BoardsController < ApplicationController
     @circular_members = @board.circular_members
     @board_checked_members = Read.where(board_id: @board.id, member_id: @circular_members.pluck(:member_id))
     @reads = Read.all
-    @read = Read.find_by(board_id: @board.id , member_id: current_member.id)
   end
 
   def new

--- a/app/controllers/public/circular_members_controller.rb
+++ b/app/controllers/public/circular_members_controller.rb
@@ -5,7 +5,6 @@ class Public::CircularMembersController < ApplicationController
   def index
     @board = Board.find(params[:board_id])
     @residence_members = @board.residence.members
-    @circular_member = CircularMember.new
   end
 
   def create
@@ -36,7 +35,6 @@ class Public::CircularMembersController < ApplicationController
     @board = Board.find(params[:board_id])
     circular_member = @board.circular_members.find_by(member_id: params[:member_id])
     @residence_members = @board.residence.members
-    @circular_member = CircularMember.new
     unless circular_member.destroy
       flash.now[:alert] = "回覧メンバーの削除に失敗しました。"
       render "index"

--- a/app/controllers/public/circular_members_controller.rb
+++ b/app/controllers/public/circular_members_controller.rb
@@ -11,11 +11,9 @@ class Public::CircularMembersController < ApplicationController
   def create
     @circular_member = CircularMember.new(circular_member_params)
     @board = Board.find(params[:board_id])
-    if @circular_member.save
-      redirect_to public_board_circular_members_path(@board)
-    else
+    @residence_members = @board.residence.members
+    unless @circular_member.save
       flash.now[:alert] = "回覧メンバーの追加に失敗しました。"
-      @residence_members = @board.residence.members
       render "index"
     end
   end
@@ -32,18 +30,15 @@ class Public::CircularMembersController < ApplicationController
         end
       end
     end
-    redirect_to public_board_circular_members_path(@board)
   end
 
   def destroy
     @board = Board.find(params[:board_id])
-    circular_member = @board.circular_members.find_by(member_id: params[:id])
-    if circular_member.destroy
-      redirect_to public_board_circular_members_path(@board)
-    else
+    circular_member = @board.circular_members.find_by(member_id: params[:member_id])
+    @residence_members = @board.residence.members
+    @circular_member = CircularMember.new
+    unless circular_member.destroy
       flash.now[:alert] = "回覧メンバーの削除に失敗しました。"
-      @residence_members = @board.residence.members
-      @circular_member = CircularMember.new
       render "index"
     end
   end

--- a/app/controllers/public/reads_controller.rb
+++ b/app/controllers/public/reads_controller.rb
@@ -4,14 +4,12 @@ class Public::ReadsController < ApplicationController
   def create
     member = current_member
     @board = Board.find(params[:board_id])
-    if Read.create(board_id: @board.id, member_id: member.id)
-      redirect_to public_board_path(@board)
-    else
+    @circular_members = @board.circular_members
+    @board_checked_members = Read.where(board_id: @board.id, member_id: @circular_members.pluck(:member_id))
+    @reads = Read.all
+    @read = Read.find_by(board_id: @board.id , member_id: member.id)
+    unless Read.create(board_id: @board.id, member_id: member.id)
       flash.now[:alert] = "既読への変更に失敗しました。"
-      @circular_members = @board.circular_members
-      @board_checked_members = Read.where(board_id: @board.id, member_id: @circular_members.pluck(:member_id))
-      @reads = Read.all
-      @read = Read.find_by(board_id: @board.id , member_id: member.id)
       render template: "public/boards/show"
     end
   end
@@ -19,13 +17,11 @@ class Public::ReadsController < ApplicationController
   def destroy
     @board = Board.find(params[:board_id])
     @read = Read.find_by(board_id: @board.id , member_id: current_member.id)
-    if @read.destroy
-      redirect_to public_board_path(@board)
-    else
+    @circular_members = @board.circular_members
+    @board_checked_members = Read.where(board_id: @board.id, member_id: @circular_members.pluck(:member_id))
+    @reads = Read.all
+    unless @read.destroy
       flash.now[:alert] = "未読への変更に失敗しました。"
-      @circular_members = @board.circular_members
-      @board_checked_members = Read.where(board_id: @board.id, member_id: @circular_members.pluck(:member_id))
-      @reads = Read.all
       render template: "public/boards/show"
     end
   end

--- a/app/views/admin/boards/show.html.erb
+++ b/app/views/admin/boards/show.html.erb
@@ -33,7 +33,7 @@
                 <% else %>
                   <span>&emsp;確認済：<%= @board_checked_members.count %>人（<%= @circular_members.count %>人中）</span>
                 <% end %>
-                <%= link_to ">>回覧メンバーを編集する", admin_board_circular_members_path(@board), class: "text-success" %>
+                <%= link_to ">>回覧メンバーを編集する", admin_board_circular_members_index_path(@board), class: "text-success" %>
               </div>
               <table class='table table-borderless'>
                 <tbody>

--- a/app/views/admin/circular_members/_add.html.erb
+++ b/app/views/admin/circular_members/_add.html.erb
@@ -4,10 +4,15 @@
       <% if member != board.member %>
         <td style="width:30%"><%= member.name %></td>
         <% if board.circular_members.exists?(member_id: member.id) %>
-          <td><%= link_to "削除", admin_board_circular_member_path(board.id, member.id), method: :delete, remote: :true, class: 'btn btn-sm btn-danger' %></td>
+          <td>
+            <%= form_with url: admin_board_circular_members_path(board), method: :delete, local: false do |f| %>
+              <%= f.hidden_field :member_id, :value => member.id %>
+              <%= f.submit "削除", class: 'btn btn-sm btn-danger' %>
+            <% end %>
+          </td>
         <% else %>
           <td>
-            <%= form_with model:@circular_member, url: admin_board_circular_members_path(board), local: false do |f| %>
+            <%= form_with model:CircularMember, url: admin_board_circular_members_path(board), local: false do |f| %>
               <%= f.hidden_field :board_id, :value => params[:board_id] %>
               <%= f.hidden_field :member_id, :value => member.id %>
               <%= f.submit "追加", class: 'btn btn-sm btn-success' %>

--- a/app/views/public/boards/_circular_members.html.erb
+++ b/app/views/public/boards/_circular_members.html.erb
@@ -1,0 +1,29 @@
+<% if board.is_circular == true %>
+  <div class="row mb-3 d-flex align-items-center">
+    <h4>回覧メンバー</h4>&emsp;
+    <% if board_checked_members.count == circular_members.count && circular_members.exists? %>
+      <span class="text-primary font-weight-bold">全員確認済</span>
+    <% elsif circular_members.count == 0 %>
+      <span>（回覧メンバーが設定されていません）</span>
+    <% else %>
+      <span>&emsp;確認済：<%= board_checked_members.count %>人（<%= circular_members.count %>人中）</span>
+    <% end %>
+    <% if board.member_id == current_member.id %>
+      <%= link_to ">>回覧メンバーを編集する", public_board_circular_members_index_path(board), class: "text-success" %>
+    <% end %>
+  </div>
+  <table class='table table-borderless'>
+    <tbody>
+      <% circular_members.each do |circular_member| %>
+        <tr>
+          <td style="width: 30%"><%= circular_member.member.name %></td>
+          <% if reads.find_by(board_id: board.id, member_id: circular_member.member_id).present? %>
+            <td class="text-primary"><i class="fa-solid fa-check"></i></td>
+          <% else %>
+            <td class="text-secondary"><i class="fa-solid fa-xmark"></i></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/public/boards/_read.html.erb
+++ b/app/views/public/boards/_read.html.erb
@@ -1,5 +1,5 @@
-<% if read.present? %>
-  <%= link_to "未読に戻す", public_board_reads_path(board), method: :delete, class: "btn btn-secondary" %>
+<% if Read.find_by(board_id: board.id , member_id: current_member.id).present? %>
+  <%= link_to "未読に戻す", public_board_reads_path(board), method: :delete, remote: true, class: "btn btn-secondary" %>
 <% else %>
-  <%= link_to "既読にする", public_board_reads_path(board), method: :post, class: "btn btn-success" %>
+  <%= link_to "既読にする", public_board_reads_path(board), method: :post, remote: true, class: "btn btn-success" %>
 <% end %>

--- a/app/views/public/boards/show.html.erb
+++ b/app/views/public/boards/show.html.erb
@@ -25,44 +25,20 @@
           <!--既読チェックボタン-->
             <div class="row">
               <div class="mx-auto">
-                <%= render 'public/boards/read', board: @board, read: @read %>
+                <div id="reads">
+                  <%= render 'public/boards/read', board: @board %>
+                </div>
               </div>
             </div>
           <!--既読チェックボタンここまで-->
           <% end %>
 
           <!--回覧メンバー表示用の記述-->
-          <% if @board.is_circular == true %>
-            <div class="mt-3">
-              <div class="row mb-3 d-flex align-items-center">
-                <h4>回覧メンバー</h4>&emsp;
-                <% if @board_checked_members.count == @circular_members.count && @circular_members.exists? %>
-                  <span class="text-primary font-weight-bold">全員確認済</span>
-                <% elsif @circular_members.count == 0 %>
-                  <span>（回覧メンバーが設定されていません）</span>
-                <% else %>
-                  <span>&emsp;確認済：<%= @board_checked_members.count %>人（<%= @circular_members.count %>人中）</span>
-                <% end %>
-                <% if @board.member_id == current_member.id %>
-                  <%= link_to ">>回覧メンバーを編集する", public_board_circular_members_path(@board), class: "text-success" %>
-                <% end %>
-              </div>
-              <table class='table table-borderless'>
-                <tbody>
-                  <% @circular_members.each do |circular_member| %>
-                    <tr>
-                      <td style="width: 30%"><%= circular_member.member.name %></td>
-                      <% if @reads.find_by(board_id: @board.id, member_id: circular_member.member_id).present? %>
-                        <td class="text-primary"><i class="fa-solid fa-check"></i></td>
-                      <% else %>
-                        <td class="text-secondary"><i class="fa-solid fa-xmark"></i></td>
-                      <% end %>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
+          <div class="mt-3">
+            <div id="circular_members">
+              <%= render 'public/boards/circular_members', board: @board, board_checked_members: @board_checked_members, circular_members: @circular_members, reads: @reads %>
             </div>
-          <% end %>
+          </div>
           <!--回覧メンバー表示用の記述ここまで-->
 
         </div>

--- a/app/views/public/circular_members/_add.html.erb
+++ b/app/views/public/circular_members/_add.html.erb
@@ -1,0 +1,26 @@
+<table class='table table-borderless'>
+  <% residence_members.each do |member| %>
+    <tr>
+      <% if member != board.member %>
+        <td style="width:30%"><%= member.name %></td>
+        <% if board.member == current_member %>
+          <% if board.circular_members.exists?(member_id: member.id) %>
+            <td>
+              <%= form_with url: public_board_circular_members_path(board), method: :delete, local: false do |f| %>
+                <%= f.hidden_field :member_id, :value => member.id %>
+                <%= f.submit "削除", class: 'btn btn-sm btn-danger' %>
+              <% end %>
+          <% else %>
+            <td>
+              <%= form_with model:CircularMember, url: public_board_circular_members_path(board), local: false do |f| %>
+                <%= f.hidden_field :board_id, :value => params[:board_id] %>
+                <%= f.hidden_field :member_id, :value => member.id %>
+                <%= f.submit "追加", class: 'btn btn-sm btn-success' %>
+              <% end %>
+            </td>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/public/circular_members/_all_add.html.erb
+++ b/app/views/public/circular_members/_all_add.html.erb
@@ -1,0 +1,3 @@
+<% if board.member == current_member && residence_members.count - 1 != board.circular_members.count %>
+  <%= link_to "全員を回覧メンバーに設定する", public_board_circular_members_add_all_path(board), method: :patch, remote: :true, class: "btn btn-primary" %>
+<% end %>

--- a/app/views/public/circular_members/add_all.js.erb
+++ b/app/views/public/circular_members/add_all.js.erb
@@ -1,0 +1,2 @@
+$('#all_add').html("<%= j(render 'public/circular_members/all_add', board: @board, residence_members: @residence_members) %>");
+$('#add').html("<%= j(render 'public/circular_members/add', board: @board, residence_members: @residence_members) %>");

--- a/app/views/public/circular_members/create.js.erb
+++ b/app/views/public/circular_members/create.js.erb
@@ -1,0 +1,2 @@
+$('#all_add').html("<%= j(render 'public/circular_members/all_add', board: @board, residence_members: @residence_members) %>");
+$('#add').html("<%= j(render 'public/circular_members/add', board: @board, residence_members: @residence_members) %>");

--- a/app/views/public/circular_members/destroy.js.erb
+++ b/app/views/public/circular_members/destroy.js.erb
@@ -1,0 +1,2 @@
+$('#all_add').html("<%= j(render 'public/circular_members/all_add', board: @board, residence_members: @residence_members) %>");
+$('#add').html("<%= j(render 'public/circular_members/add', board: @board, residence_members: @residence_members) %>");

--- a/app/views/public/circular_members/index.html.erb
+++ b/app/views/public/circular_members/index.html.erb
@@ -3,36 +3,15 @@
     <div class="row ml-5 mb-3">
       <h2>回覧メンバー編集</h2>
       <div class="ml-3">
-        <% if @board.member == current_member %>  <!--掲示板投稿者が管理人でない場合-->
-          <% if @residence_members.count - 1 != @board.circular_members.count %>　<!--掲示板投稿者が未退会の場合-->
-            <%= link_to "全員を回覧メンバーに設定する", public_board_circular_members_add_all_path(@board), method: :patch, class: "btn btn-primary" %>
-          <% end %>
-        <% end %>
+        <div id="all_add">
+          <%= render 'public/circular_members/all_add', board: @board, residence_members: @residence_members %>
+        </div>
       </div>
     </div>
     <div class="ml-5 mb-3">
-      <table class='table table-borderless'>
-        <% @residence_members.each do |member| %>
-          <tr>
-            <% if member != @board.member %>
-              <td style="width:30%"><%= member.name %></td>
-              <% if @board.member == current_member %>
-                <% if @board.circular_members.exists?(member_id: member.id) %>
-                  <td><%= link_to "削除", public_board_circular_member_path(@board.id, member.id), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                <% else %>
-                  <td>
-                    <%= form_with model:@circular_member, url: public_board_circular_members_path(@board), local: true do |f| %>
-                      <%= f.hidden_field :board_id, :value => params[:board_id] %>
-                      <%= f.hidden_field :member_id, :value => member.id %>
-                      <%= f.submit "追加", class: 'btn btn-sm btn-success' %>
-                    <% end %>
-                  </td>
-                <% end %>
-              <% end %>
-            <% end %>
-          </tr>
-        <% end %>
-      </table>
+      <div id="add">
+        <%= render 'public/circular_members/add', board: @board, residence_members: @residence_members %>
+      </div>
       <div class="text-right">
         <%= link_to "掲示板詳細へ", public_board_path(@board) %>
       </div>

--- a/app/views/public/reads/create.js.erb
+++ b/app/views/public/reads/create.js.erb
@@ -1,0 +1,2 @@
+$('#reads').html("<%= j(render 'public/boards/read', board: @board) %>");
+$('#circular_members').html("<%= j(render 'public/boards/circular_members', board: @board, board_checked_members: @board_checked_members, circular_members: @circular_members, reads: @reads) %>");

--- a/app/views/public/reads/destroy.js.erb
+++ b/app/views/public/reads/destroy.js.erb
@@ -1,0 +1,2 @@
+$('#reads').html("<%= j(render 'public/boards/read', board: @board) %>");
+$('#circular_members').html("<%= j(render 'public/boards/circular_members', board: @board, board_checked_members: @board_checked_members, circular_members: @circular_members, reads: @reads) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,8 @@ Rails.application.routes.draw do
       collection do
         get "residence/:id" => "boards#residence_search" ,as: "residence_search"
       end
-      resources :circular_members, only: [:index, :create, :destroy]
+      resource :circular_members, only: [:create, :destroy]
+      get "circuler_members" => "circular_members#index", as: "circular_members_index"
       patch "circular_members_add_all" => "circular_members#add_all", as: "circular_members_add_all"
     end
     resources :residences, except: [:index, :show]
@@ -70,7 +71,7 @@ Rails.application.routes.draw do
     get "search/result" => "searches#search_result", as: "search_result"
   end
 
-  namespace :public do               
+  namespace :public do
     resources :plans
     resources :events do
       resources :event_members, only: [:index, :create, :update, :destroy]
@@ -91,7 +92,8 @@ Rails.application.routes.draw do
     resources :equipments, only: [:index, :show]
     resources :facilities, only: [:index, :show]
     resources :boards do
-      resources :circular_members, only: [:index, :create, :destroy]
+      resource :circular_members, only: [:create, :destroy]
+      get "circuler_members" => "circular_members#index", as: "circular_members_index"
       patch "circular_members_add_all" => "circular_members#add_all", as: "circular_members_add_all"
       resource :reads, only: [:create, :destroy]
     end


### PR DESCRIPTION
・共通
回覧メンバーのルーティングを一部変更(不要なIDを削除)
∟合わせて各所記述修正

・会員
掲示板の一部機能を非同期化
∟既読ボタン
∟回覧メンバーの設定・削除ボタン
∟回覧メンバーの全追加ボタン